### PR TITLE
Add terraform scripts

### DIFF
--- a/terraform/environments/main.tf
+++ b/terraform/environments/main.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.11"
+    }
+  }
+  required_version = ">= 1.2.0"
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+    }
+  }
+} 

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -1,0 +1,97 @@
+module "vpc" {
+  source = "../../modules/vpc"
+
+  environment     = var.environment
+  vpc_cidr        = var.vpc_cidr
+  public_subnets  = var.public_subnets
+  private_subnets = var.private_subnets
+}
+
+module "eks" {
+  source = "../../modules/eks"
+
+  environment                = var.environment
+  eks_cluster_name          = var.eks_cluster_name
+  vpc_id                    = module.vpc.vpc_id
+  private_subnet_ids        = module.vpc.private_subnet_ids
+  eks_node_group_instance_type = var.eks_node_group_instance_type
+  datadog_api_key           = var.datadog_api_key
+}
+
+module "rds" {
+  source = "../../modules/rds"
+
+  environment                = var.environment
+  vpc_id                    = module.vpc.vpc_id
+  private_subnet_ids        = module.vpc.private_subnet_ids
+  rds_instance_class        = var.rds_instance_class
+  rds_allocated_storage     = var.rds_allocated_storage
+  rds_backup_retention_period = var.rds_backup_retention_period
+  rds_backup_window         = var.rds_backup_window
+  rds_maintenance_window    = var.rds_maintenance_window
+  db_name                   = var.db_name
+  db_username               = var.db_username
+  db_password               = var.db_password
+  allowed_security_groups   = [module.eks.cluster_security_group_id]
+}
+
+module "application_gateway" {
+  source = "../../modules/application_gateway"
+
+  environment      = var.environment
+  vpc_id          = module.vpc.vpc_id
+  public_subnet_ids = module.vpc.public_subnet_ids
+  route53_zone_id = var.route53_zone_id
+}
+
+# CloudWatch Alarms
+resource "aws_cloudwatch_metric_alarm" "alb_5xx_errors" {
+  alarm_name          = "${var.environment}-alb-5xx-errors"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "HTTPCode_Target_5XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  period             = "300"
+  statistic          = "Sum"
+  threshold          = "10"
+  alarm_description  = "This metric monitors ALB 5XX errors"
+  alarm_actions      = [var.sns_topic_arn]
+
+  dimensions = {
+    LoadBalancer = module.application_gateway.alb_arn_suffix
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_cpu_utilization" {
+  alarm_name          = "${var.environment}-rds-cpu-utilization"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/RDS"
+  period             = "300"
+  statistic          = "Average"
+  threshold          = "80"
+  alarm_description  = "This metric monitors RDS CPU utilization"
+  alarm_actions      = [var.sns_topic_arn]
+
+  dimensions = {
+    DBInstanceIdentifier = module.rds.db_instance_id
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "eks_node_cpu_utilization" {
+  alarm_name          = "${var.environment}-eks-node-cpu-utilization"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period             = "300"
+  statistic          = "Average"
+  threshold          = "80"
+  alarm_description  = "This metric monitors EKS node CPU utilization"
+  alarm_actions      = [var.sns_topic_arn]
+
+  dimensions = {
+    AutoScalingGroupName = module.eks.node_group_name
+  }
+} 

--- a/terraform/environments/variables.tf
+++ b/terraform/environments/variables.tf
@@ -1,0 +1,71 @@
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "production"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnets" {
+  description = "CIDR blocks for public subnets"
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "private_subnets" {
+  description = "CIDR blocks for private subnets"
+  type        = list(string)
+  default     = ["10.0.3.0/24", "10.0.4.0/24"]
+}
+
+variable "eks_cluster_name" {
+  description = "Name of the EKS cluster"
+  type        = string
+  default     = "training-cluster"
+}
+
+variable "eks_node_group_instance_type" {
+  description = "Instance type for EKS node group"
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "rds_instance_class" {
+  description = "RDS instance class"
+  type        = string
+  default     = "db.t3.large"
+}
+
+variable "rds_allocated_storage" {
+  description = "RDS allocated storage in GB"
+  type        = number
+  default     = 200
+}
+
+variable "rds_backup_retention_period" {
+  description = "RDS backup retention period in days"
+  type        = number
+  default     = 7
+}
+
+variable "rds_backup_window" {
+  description = "RDS backup window"
+  type        = string
+  default     = "03:00-09:00"
+}
+
+variable "rds_maintenance_window" {
+  description = "RDS maintenance window"
+  type        = string
+  default     = "Mon:00:00-Mon:03:00"
+}
+
+variable "datadog_api_key" {
+  description = "Datadog API key"
+  type        = string
+  sensitive   = true
+} 

--- a/terraform/modules/application_gateway/main.tf
+++ b/terraform/modules/application_gateway/main.tf
@@ -1,0 +1,119 @@
+resource "aws_acm_certificate" "training" {
+  domain_name       = "training.inflection.io"
+  validation_method = "DNS"
+
+  tags = {
+    Name        = "${var.environment}-training-cert"
+    Environment = var.environment
+  }
+}
+
+resource "aws_route53_record" "training_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.training.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = var.route53_zone_id
+}
+
+resource "aws_acm_certificate_validation" "training" {
+  certificate_arn         = aws_acm_certificate.training.arn
+  validation_record_fqdns = [for record in aws_route53_record.training_validation : record.fqdn]
+}
+
+resource "aws_alb" "training" {
+  name               = "${var.environment}-training-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = var.public_subnet_ids
+
+  tags = {
+    Name        = "${var.environment}-training-alb"
+    Environment = var.environment
+  }
+}
+
+resource "aws_alb_listener" "https" {
+  load_balancer_arn = aws_alb.training.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = aws_acm_certificate_validation.training.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.training.arn
+  }
+}
+
+resource "aws_alb_target_group" "training" {
+  name        = "${var.environment}-training-tg"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    enabled             = true
+    interval            = 30
+    path                = "/health"
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    matcher             = "200"
+  }
+
+  tags = {
+    Name        = "${var.environment}-training-tg"
+    Environment = var.environment
+  }
+}
+
+resource "aws_security_group" "alb" {
+  name        = "${var.environment}-alb-sg"
+  description = "Security group for ALB"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "${var.environment}-alb-sg"
+    Environment = var.environment
+  }
+}
+
+resource "aws_route53_record" "training" {
+  zone_id = var.route53_zone_id
+  name    = "training.inflection.io"
+  type    = "A"
+
+  alias {
+    name                   = aws_alb.training.dns_name
+    zone_id                = aws_alb.training.zone_id
+    evaluate_target_health = true
+  }
+} 

--- a/terraform/modules/application_gateway/variables.tf
+++ b/terraform/modules/application_gateway/variables.tf
@@ -1,0 +1,19 @@
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "public_subnet_ids" {
+  description = "List of public subnet IDs"
+  type        = list(string)
+}
+
+variable "route53_zone_id" {
+  description = "Route53 zone ID"
+  type        = string
+} 

--- a/terraform/modules/eks/main.tf
+++ b/terraform/modules/eks/main.tf
@@ -1,0 +1,78 @@
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 19.0"
+
+  cluster_name    = var.eks_cluster_name
+  cluster_version = "1.27"
+
+  vpc_id                         = var.vpc_id
+  subnet_ids                     = var.private_subnet_ids
+  cluster_endpoint_public_access = true
+
+  eks_managed_node_groups = {
+    default = {
+      min_size     = 1
+      max_size     = 3
+      desired_size = 2
+
+      instance_types = [var.eks_node_group_instance_type]
+      capacity_type  = "ON_DEMAND"
+
+      labels = {
+        Environment = var.environment
+      }
+
+      tags = {
+        Environment = var.environment
+      }
+    }
+  }
+
+  tags = {
+    Environment = var.environment
+  }
+}
+
+resource "helm_release" "datadog" {
+  name       = "datadog"
+  repository = "https://helm.datadoghq.com"
+  chart      = "datadog"
+  version    = "3.8.0"
+
+  set {
+    name  = "datadog.apiKey"
+    value = var.datadog_api_key
+  }
+
+  set {
+    name  = "datadog.site"
+    value = "datadoghq.com"
+  }
+
+  set {
+    name  = "datadog.logs.enabled"
+    value = true
+  }
+
+  set {
+    name  = "datadog.logs.containerCollectAll"
+    value = true
+  }
+
+  set {
+    name  = "datadog.apm.enabled"
+    value = true
+  }
+
+  set {
+    name  = "datadog.processAgent.enabled"
+    value = true
+  }
+
+  set {
+    name  = "datadog.systemProbe.enabled"
+    value = true
+  }
+
+  depends_on = [module.eks]
+} 

--- a/terraform/modules/eks/variables.tf
+++ b/terraform/modules/eks/variables.tf
@@ -1,0 +1,30 @@
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "eks_cluster_name" {
+  description = "Name of the EKS cluster"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  type        = list(string)
+}
+
+variable "eks_node_group_instance_type" {
+  description = "Instance type for EKS node group"
+  type        = string
+}
+
+variable "datadog_api_key" {
+  description = "Datadog API key"
+  type        = string
+  sensitive   = true
+} 

--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -1,0 +1,82 @@
+resource "aws_db_subnet_group" "main" {
+  name       = "${var.environment}-db-subnet-group"
+  subnet_ids = var.private_subnet_ids
+
+  tags = {
+    Name        = "${var.environment}-db-subnet-group"
+    Environment = var.environment
+  }
+}
+
+resource "aws_db_instance" "main" {
+  identifier             = "${var.environment}-db"
+  engine                 = "postgres"
+  engine_version         = "14.7"
+  instance_class         = var.rds_instance_class
+  allocated_storage      = var.rds_allocated_storage
+  max_allocated_storage  = var.rds_allocated_storage * 2
+  storage_type           = "gp3"
+  storage_encrypted      = true
+  kms_key_id            = aws_kms_key.rds.arn
+
+  db_name  = var.db_name
+  username = var.db_username
+  password = var.db_password
+  port     = 5432
+
+  multi_az               = true
+  publicly_accessible    = false
+  vpc_security_group_ids = [aws_security_group.rds.id]
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+
+  backup_retention_period = var.rds_backup_retention_period
+  backup_window          = var.rds_backup_window
+  maintenance_window     = var.rds_maintenance_window
+
+  skip_final_snapshot = false
+  final_snapshot_identifier = "${var.environment}-final-snapshot"
+
+  enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
+
+  performance_insights_enabled = true
+  performance_insights_retention_period = 7
+
+  tags = {
+    Name        = "${var.environment}-db"
+    Environment = var.environment
+  }
+}
+
+resource "aws_security_group" "rds" {
+  name        = "${var.environment}-rds-sg"
+  description = "Security group for RDS instance"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = var.allowed_security_groups
+  }
+
+  tags = {
+    Name        = "${var.environment}-rds-sg"
+    Environment = var.environment
+  }
+}
+
+resource "aws_kms_key" "rds" {
+  description             = "KMS key for RDS encryption"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+
+  tags = {
+    Name        = "${var.environment}-rds-kms"
+    Environment = var.environment
+  }
+}
+
+resource "aws_kms_alias" "rds" {
+  name          = "alias/${var.environment}-rds-kms"
+  target_key_id = aws_kms_key.rds.key_id
+} 

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -1,0 +1,60 @@
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  type        = list(string)
+}
+
+variable "rds_instance_class" {
+  description = "RDS instance class"
+  type        = string
+}
+
+variable "rds_allocated_storage" {
+  description = "RDS allocated storage in GB"
+  type        = number
+}
+
+variable "rds_backup_retention_period" {
+  description = "RDS backup retention period in days"
+  type        = number
+}
+
+variable "rds_backup_window" {
+  description = "RDS backup window"
+  type        = string
+}
+
+variable "rds_maintenance_window" {
+  description = "RDS maintenance window"
+  type        = string
+}
+
+variable "db_name" {
+  description = "Database name"
+  type        = string
+}
+
+variable "db_username" {
+  description = "Database username"
+  type        = string
+}
+
+variable "db_password" {
+  description = "Database password"
+  type        = string
+  sensitive   = true
+}
+
+variable "allowed_security_groups" {
+  description = "List of security group IDs allowed to access RDS"
+  type        = list(string)
+} 

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -1,0 +1,109 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name        = "${var.environment}-vpc"
+    Environment = var.environment
+  }
+}
+
+resource "aws_subnet" "public" {
+  count             = length(var.public_subnets)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.public_subnets[count.index]
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  tags = {
+    Name        = "${var.environment}-public-subnet-${count.index + 1}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_subnet" "private" {
+  count             = length(var.private_subnets)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnets[count.index]
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  tags = {
+    Name        = "${var.environment}-private-subnet-${count.index + 1}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name        = "${var.environment}-igw"
+    Environment = var.environment
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name        = "${var.environment}-public-rt"
+    Environment = var.environment
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(var.public_subnets)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_eip" "nat" {
+  count  = length(var.public_subnets)
+  domain = "vpc"
+
+  tags = {
+    Name        = "${var.environment}-nat-eip-${count.index + 1}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_nat_gateway" "main" {
+  count         = length(var.public_subnets)
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags = {
+    Name        = "${var.environment}-nat-gw-${count.index + 1}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_route_table" "private" {
+  count  = length(var.private_subnets)
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main[count.index].id
+  }
+
+  tags = {
+    Name        = "${var.environment}-private-rt-${count.index + 1}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(var.private_subnets)
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+} 

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -1,0 +1,19 @@
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+}
+
+variable "public_subnets" {
+  description = "CIDR blocks for public subnets"
+  type        = list(string)
+}
+
+variable "private_subnets" {
+  description = "CIDR blocks for private subnets"
+  type        = list(string)
+} 


### PR DESCRIPTION
Problem description:
create a terraform file for AWS that has the following components:
1. A public endpoint called https://training.inflection.io on AWS application gateway.
2. An EKS cluster in us-east-1 which hosts a java application that needs 4gb of RAM, 2 cores and 32gb of disk each. This cluster needs to have sidecar installations of datadog agent for monitoring
3. An RDS instance that is highly available  across multiple data centers. This RDS should support at least 200GB of data on disk and should have backups enabled every 6 hours
4. Cloudwatch enabled for issues in application gateway, EKS and RDS